### PR TITLE
 missing newline preventing build  added

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,4 +2,6 @@
 
 Run `sbt package`.
 
-If compilation succeeds, `py.jar` will be created. This file and `pyext.py` should then be placed in a folder named `py` in your NetLogo `extensions` directory.
+Make sure your sbt is at least at version 0.13.6
+
+If compilation succeeds, `py.jar` will be created in the py directory. Copy the `py` directory to your NetLogo `extensions` directory.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ https://github.com/NetLogo/Python-Extension is now the canonical version of this
 This NetLogo extension allows you to run Python code from NetLogo. It works with both Python 2 and 3, and should work with almost all Python libraries.
 
 ## Building
+Make sure your sbt is at least at version 0.13.6
 
 Run `sbt package`.
 
-If compilation succeeds, `py.jar` will be created. This file and `pyext.py` should then be placed in a folder named `py` in your NetLogo `extensions` directory.
+If compilation succeeds, `py.jar` will be created. If compilation succeeds, `py.jar` will be created in the py directory. Copy the `py` directory to your NetLogo `extensions` directory.
+
 ## Using
 
 As with all NetLogo extensions, you must declare that you're using this extension in your NetLogo code with:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,5 @@ resolvers += Resolver.url(
     Resolver.ivyStylePatterns)
 
 addSbtPlugin("org.nlogo" % "netlogo-extension-plugin" % "3.0")
+
 addSbtPlugin("org.nlogo" % "netlogo-extension-documentation" % "0.7.2")


### PR DESCRIPTION
Now the compilation starts, but till throws an error

$ sbt project
[info] Loading project definition from /home/igor/git/Python-Extension/project
[info] Updating {file:/home/igor/git/Python-Extension/project/}python-extension-build...
[info] Resolving org.scala-sbt#compiler-interface;0.13.16 ...
[info] Done updating.
/home/igor/git/Python-Extension/build.sbt:1: error: not found: value enablePlugins
enablePlugins(org.nlogo.build.NetLogoExtension)

will investigate further