### PR TITLE
CI: Run once a week

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 env:
   LIBERICA_URL: https://download.bell-sw.com/java/17.0.5+8/bellsoft-jdk17.0.5+8-linux-amd64-full.tar.gz


### PR DESCRIPTION
Run the CI once a week to check everything keeps working as environments get updated, new Python version and packages get released, etc.

Once a build fails, we only have to check what changed in the past week instead of the past 6+ months.